### PR TITLE
Show lists-containers at 400px on the demo page

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -68,12 +68,12 @@ caption {
 }
 
 .lists-container {
-  display: block;
+  display: none;
 }
 
-@media (min-width: 400px) {
+@media (max-width: 400px) {
   .lists-container {
-    display: none;
+    display: block;
   }
 }
 


### PR DESCRIPTION
Lists container with `dl/dt` on https://heydon.github.io/react-sortable-table-demo/ wasn‘t visible at 400px or lower. Fixed that!